### PR TITLE
fixed override onMethodCall to adhere interface

### DIFF
--- a/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
+++ b/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
@@ -136,7 +136,7 @@ class QRView(private val registrar: PluginRegistry.Registrar, id: Int) :
     }
 
 
-    override fun onMethodCall(call: MethodCall?, result: MethodChannel.Result?) {
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when(call?.method){
             "checkAndRequestPermission" -> {
                 checkAndRequestPermission(result)


### PR DESCRIPTION
Fix to issue#19 (https://github.com/juliuscanute/qr_code_scanner/issues/19)

the code must be updated, it seems that the io.flutter.plugin.common.MethodCall interface has changed and the override must be updated