### PR TITLE
Fix for Android flash toggle

### DIFF
--- a/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
+++ b/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
@@ -30,6 +30,7 @@ class QRView(private val registrar: PluginRegistry.Registrar, id: Int) :
     private val activity = registrar.activity()
     var cameraPermissionContinuation: Runnable? = null
     var requestingPermission = false
+    private var isTorchOn: Boolean = false
     val channel: MethodChannel
 
     init {
@@ -80,13 +81,19 @@ class QRView(private val registrar: PluginRegistry.Registrar, id: Int) :
         barcodeView?.resume()
     }
 
-    fun flipFlash() {
-        barcodeView?.pause()
-        var settings = barcodeView?.cameraSettings
-        settings?.isAutoTorchEnabled = ! (settings?.isAutoTorchEnabled?:false)
-        barcodeView?.resume()
+    private fun toggleFlash() {
+        if (hasFlash()) {
+            barcodeView?.setTorch(!isTorchOn)
+            isTorchOn = !isTorchOn
+        }
+
     }
 
+
+    private fun hasFlash(): Boolean {
+        return registrar.activeContext().packageManager
+                .hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH)
+    }
 
     override fun getView(): View {
         return initBarCodeView()?.apply {
@@ -132,7 +139,7 @@ class QRView(private val registrar: PluginRegistry.Registrar, id: Int) :
 
     private fun hasCameraPermission(): Boolean {
         return Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
-                activity.checkSelfPermission(Manifest.permission.CAMERA) === PackageManager.PERMISSION_GRANTED
+                activity.checkSelfPermission(Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED
     }
 
 
@@ -144,8 +151,8 @@ class QRView(private val registrar: PluginRegistry.Registrar, id: Int) :
             "flipCamera" -> {
                 flipCamera()
             }
-            "flipFlash" -> {
-                flipFlash()
+            "toggleFlash" -> {
+                toggleFlash()
             }
         }
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,7 +50,7 @@ class _QRViewExampleState extends State<QRViewExample> {
                       child: RaisedButton(
                         onPressed: () {
                           if (controller != null) {
-                            controller.flipFlash();
+                            controller.toggleFlash();
                             if (_isFlashOn(flashState))
                               setState(() {
                                 flashState = flash_off;

--- a/ios/Classes/QRView.swift
+++ b/ios/Classes/QRView.swift
@@ -48,8 +48,12 @@ public class QRView:NSObject,FlutterPlatformView {
                     self?.setDimensions(width: arguments["width"] ?? 0,height: arguments["height"] ?? 0)
                 case "flipCamera":
                     self?.flipCamera()
-                case "flipFlash":
-                    self?.flipFlash()
+                case "toggleFlash":
+                    self?.toggleFlash()
+                case "pauseCamera":
+                    self?.pauseCamera()
+                case "resumeCamera":
+                    self?.resumeCamera()
                 default:
                     result(FlutterMethodNotImplemented)
                     return
@@ -72,7 +76,7 @@ public class QRView:NSObject,FlutterPlatformView {
         }
     }
     
-    func flipFlash(){
+    func toggleFlash(){
         if let sc: MTBBarcodeScanner = scanner {
             if sc.hasTorch() {
                 sc.toggleTorch()

--- a/lib/qr_code_scanner.dart
+++ b/lib/qr_code_scanner.dart
@@ -83,12 +83,11 @@ class QRViewController {
     }
   }
 
-  void flipCamera(){
+  void flipCamera() {
     channel.invokeMethod("flipCamera");
   }
 
-  void flipFlash(){
-    channel.invokeMethod("flipFlash");
+  void toggleFlash() {
+    channel.invokeMethod("toggleFlash");
   }
-
 }


### PR DESCRIPTION
I noticed that the flipFlash function wasn't very reliable, that's why I investigated and noticed the Android implementation didnt't actually turn on/off the flash, but rather turned on/off the option for autoflash, which depends on the current brightness.
```
fun flipFlash() {
    barcodeView?.pause()
    var settings = barcodeView?.cameraSettings
    settings?.isAutoTorchEnabled = ! (settings?.isAutoTorchEnabled?:false)
    barcodeView?.resume()
} 
```
To actually stay consistent with the iOS implementation, which doesn't feature autoflash, I removed it from the android side and implemented a simple flash toggle. Now you'll have the same behavior on android and on iOS. It also eliminates the need to pause/resume the camera preview, which makes it a lot smoother.