### PR TITLE
Draw overlay based on rect position

### DIFF
--- a/lib/src/qr_scanner_overlay_shape.dart
+++ b/lib/src/qr_scanner_overlay_shape.dart
@@ -87,8 +87,8 @@ class QrScannerOverlayShape extends ShapeBorder {
       ..blendMode = BlendMode.dstOut;
 
     final cutOutRect = Rect.fromLTWH(
-      width / 2 - _cutOutSize / 2 + borderOffset,
-      height / 2 - _cutOutSize / 2 + borderOffset,
+      rect.left + width / 2 - _cutOutSize / 2 + borderOffset,
+      rect.top + height / 2 - _cutOutSize / 2 + borderOffset,
       _cutOutSize - borderOffset * 2,
       _cutOutSize - borderOffset * 2,
     );


### PR DESCRIPTION
For a `QRView` that doesn't originate in the top-left corner of the screen, the `QrScannerOverlayShape` wasn't drawn in the center of the `QRView`. This PR adds the proper offsets to the `cutOutRect`. This fixes #40.