### PR TITLE
Fixed iOS crash due to force unwrap of nil

### DIFF
--- a/ios/Classes/QRView.swift
+++ b/ios/Classes/QRView.swift
@@ -26,10 +26,8 @@ public class QRView:NSObject,FlutterPlatformView {
                 try scanner?.startScanning(resultBlock: { codes in
                     if let codes = codes {
                         for code in codes {
-                            if (code != nil && code.stringValue != nil) {
-                                let stringValue = code.stringValue!
-                                self.channel.invokeMethod("onRecognizeQR", arguments: stringValue)
-                            }
+                            guard let stringValue = code.stringValue else { continue }
+                            self.channel.invokeMethod("onRecognizeQR", arguments: stringValue)
                         }
                     }
                 })


### PR DESCRIPTION
In swift code, there was a force unwrap that crashed the app when the scanned code was not in string format. This may happen when application scans something that it thinks is a QR code.

We will get error as follows:
```
Exception Type:  EXC_BREAKPOINT (SIGTRAP)
Exception Codes: 0x0000000000000001, 0x00000001065c1f00
Termination Signal: Trace/BPT trap: 5
Termination Reason: Namespace SIGNAL, Code 0x5
Terminating Process: exc handler [3633]
Triggered by Thread:  0

Thread 0 name:
Thread 0 Crashed:
0   qr_code_scanner               	0x00000001065c1f00 closure #1 in QRView.isCameraAvailable(success:) + 508 (QRView.swift:29)
1   qr_code_scanner               	0x00000001065c1dc4 closure #1 in QRView.isCameraAvailable(success:) + 192 (QRView.swift:29)
2   qr_code_scanner               	0x00000001065c1f68 thunk for @escaping @callee_guaranteed (@guaranteed [AVMetadataMachineReadableCodeObject]?) -> () + 100 (<compiler-generated>:0)
3   MTBBarcodeScanner             	0x0000000105d7c7dc -[MTBBarcodeScanner captureOutput:didOutputMetadataObjects:fromConnection:] + 444 (MTBBarcodeScanner.m:462)
4   AVFoundation                  	0x00000001
```

I fixed this by changing force unwrap to guard let syntax.