### PR TITLE
Fix crash when code.stringValue is nil

### DIFF
--- a/ios/Classes/QRView.swift
+++ b/ios/Classes/QRView.swift
@@ -26,8 +26,9 @@ public class QRView:NSObject,FlutterPlatformView {
                 try scanner?.startScanning(resultBlock: { codes in
                     if let codes = codes {
                         for code in codes {
-                            let stringValue = code.stringValue!
-                            self.channel.invokeMethod("onRecognizeQR", arguments: stringValue)
+                            if let stringValue = code.stringValue {
+                                self.channel.invokeMethod("onRecognizeQR", arguments: stringValue)
+                            }
                         }
                     }
                 })


### PR DESCRIPTION
I experienced this crash when I was using the scanner.  Specifically I was pointing the camera not to a QR code, but just to my room, and the code crashed in the line `code.stringValue!`, so the fix consists just to be sure that stringValue can be unwrapped avoiding such crash


CC- @juliuscanute