### PR TITLE
Nil safe code scanning for iOS

### DIFF
--- a/ios/Classes/QRView.swift
+++ b/ios/Classes/QRView.swift
@@ -26,8 +26,10 @@ public class QRView:NSObject,FlutterPlatformView {
                 try scanner?.startScanning(resultBlock: { codes in
                     if let codes = codes {
                         for code in codes {
-                            let stringValue = code.stringValue!
-                            self.channel.invokeMethod("onRecognizeQR", arguments: stringValue)
+                            if (code != nil && code.stringValue != nil) {
+                                let stringValue = code.stringValue!
+                                self.channel.invokeMethod("onRecognizeQR", arguments: stringValue)
+                            }
                         }
                     }
                 })


### PR DESCRIPTION
The issue:
Sometimes the scanner returns nil object instead of scanned code

Preconditions:
Phone: iPhone XS Max
Monitor: any with TN+film matrix

Steps to reproduce:
Scan any web-page with a white background and black text color

AR:
App crashes because of nil code

ER:
App does not crash and continues scanning codes

![ezgif-3-9fc1a3db2ad2](https://user-images.githubusercontent.com/10255994/74231821-2243d200-4cd0-11ea-9600-4b697f1b6901.gif)

