### PR TITLE
Add cutout bottom offset

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -40,6 +40,7 @@ class _QRViewExampleState extends State<QRViewExample> {
                 borderLength: 30,
                 borderWidth: 10,
                 cutOutSize: 300,
+                cutOutBottomOffset: 24,
               ),
             ),
           ),

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -11,6 +11,7 @@ class QRView extends StatefulWidget {
     @required Key key,
     @required this.onQRViewCreated,
     this.overlay,
+    this.overlayMargin = EdgeInsets.zero,
   })  : assert(key != null),
         assert(onQRViewCreated != null),
         super(key: key);
@@ -18,6 +19,7 @@ class QRView extends StatefulWidget {
   final QRViewCreatedCallback onQRViewCreated;
 
   final ShapeBorder overlay;
+  final EdgeInsetsGeometry overlayMargin;
 
   @override
   State<StatefulWidget> createState() => _QRViewState();
@@ -31,6 +33,7 @@ class _QRViewState extends State<QRView> {
         _getPlatformQrView(),
         if (widget.overlay != null)
           Container(
+            padding: widget.overlayMargin,
             decoration: ShapeDecoration(
               shape: widget.overlay,
             ),

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -11,7 +11,6 @@ class QRView extends StatefulWidget {
     @required Key key,
     @required this.onQRViewCreated,
     this.overlay,
-    this.overlayMargin = EdgeInsets.zero,
   })  : assert(key != null),
         assert(onQRViewCreated != null),
         super(key: key);
@@ -19,7 +18,6 @@ class QRView extends StatefulWidget {
   final QRViewCreatedCallback onQRViewCreated;
 
   final ShapeBorder overlay;
-  final EdgeInsetsGeometry overlayMargin;
 
   @override
   State<StatefulWidget> createState() => _QRViewState();
@@ -33,7 +31,6 @@ class _QRViewState extends State<QRView> {
         _getPlatformQrView(),
         if (widget.overlay != null)
           Container(
-            padding: widget.overlayMargin,
             decoration: ShapeDecoration(
               shape: widget.overlay,
             ),

--- a/lib/src/qr_scanner_overlay_shape.dart
+++ b/lib/src/qr_scanner_overlay_shape.dart
@@ -10,6 +10,7 @@ class QrScannerOverlayShape extends ShapeBorder {
     this.borderRadius = 0,
     this.borderLength = 40,
     this.cutOutSize = 250,
+    this.cutOutBottomOffset = 0,
   }) : assert(
             cutOutSize != null ??
                 cutOutSize != null ??
@@ -22,6 +23,7 @@ class QrScannerOverlayShape extends ShapeBorder {
   final double borderRadius;
   final double borderLength;
   final double cutOutSize;
+  final double cutOutBottomOffset;
 
   @override
   EdgeInsetsGeometry get dimensions => const EdgeInsets.all(10);
@@ -86,7 +88,11 @@ class QrScannerOverlayShape extends ShapeBorder {
 
     final cutOutRect = Rect.fromLTWH(
       rect.left + width / 2 - _cutOutSize / 2 + borderOffset,
-      rect.top + height / 2 - _cutOutSize / 2 + borderOffset,
+      -cutOutBottomOffset +
+          rect.top +
+          height / 2 -
+          _cutOutSize / 2 +
+          borderOffset,
       _cutOutSize - borderOffset * 2,
       _cutOutSize - borderOffset * 2,
     );


### PR DESCRIPTION
This simple PR adds a property to `QrScannerOverlayShape` in order to customise the cutout vertical position.