### PR TITLE
Fix an issue when Scanner size is broken after iPad rotation

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
 
@@ -31,17 +33,7 @@ class _QRViewExampleState extends State<QRViewExample> {
         children: <Widget>[
           Expanded(
             flex: 4,
-            child: QRView(
-              key: qrKey,
-              onQRViewCreated: _onQRViewCreated,
-              overlay: QrScannerOverlayShape(
-                borderColor: Colors.red,
-                borderRadius: 10,
-                borderLength: 30,
-                borderWidth: 10,
-                cutOutSize: 300,
-              ),
-            ),
+            child: _buildQrView(context)
           ),
           Expanded(
             flex: 1,
@@ -153,5 +145,27 @@ class _QRViewExampleState extends State<QRViewExample> {
   void dispose() {
     controller.dispose();
     super.dispose();
+  }
+
+  Widget _buildQrView(BuildContext context) {
+    // To ensure the Scanner view is properly sizes after rotation
+    // we need to listen for Flutter SizeChanged notifiation and update controller
+    return NotificationListener<SizeChangedLayoutNotification>(onNotification: (notification) {
+      Future.microtask(() => controller?.updateDimensions(qrKey));
+      return false;
+    }, child: SizeChangedLayoutNotifier(
+      key: const Key('qr-size-notifier'), 
+      child: QRView(
+        key: qrKey,
+        onQRViewCreated: _onQRViewCreated,
+        overlay: QrScannerOverlayShape(
+          borderColor: Colors.red,
+          borderRadius: 10,
+          borderLength: 30,
+          borderWidth: 10,
+          cutOutSize: 300,
+        ),
+      ))
+    );
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,10 +31,7 @@ class _QRViewExampleState extends State<QRViewExample> {
     return Scaffold(
       body: Column(
         children: <Widget>[
-          Expanded(
-            flex: 4,
-            child: _buildQrView(context)
-          ),
+          Expanded(flex: 4, child: _buildQrView(context)),
           Expanded(
             flex: 1,
             child: FittedBox(
@@ -150,22 +147,23 @@ class _QRViewExampleState extends State<QRViewExample> {
   Widget _buildQrView(BuildContext context) {
     // To ensure the Scanner view is properly sizes after rotation
     // we need to listen for Flutter SizeChanged notifiation and update controller
-    return NotificationListener<SizeChangedLayoutNotification>(onNotification: (notification) {
-      Future.microtask(() => controller?.updateDimensions(qrKey));
-      return false;
-    }, child: SizeChangedLayoutNotifier(
-      key: const Key('qr-size-notifier'), 
-      child: QRView(
-        key: qrKey,
-        onQRViewCreated: _onQRViewCreated,
-        overlay: QrScannerOverlayShape(
-          borderColor: Colors.red,
-          borderRadius: 10,
-          borderLength: 30,
-          borderWidth: 10,
-          cutOutSize: 300,
-        ),
-      ))
-    );
+    return NotificationListener<SizeChangedLayoutNotification>(
+        onNotification: (notification) {
+          Future.microtask(() => controller?.updateDimensions(qrKey));
+          return false;
+        },
+        child: SizeChangedLayoutNotifier(
+            key: const Key('qr-size-notifier'),
+            child: QRView(
+              key: qrKey,
+              onQRViewCreated: _onQRViewCreated,
+              overlay: QrScannerOverlayShape(
+                borderColor: Colors.red,
+                borderRadius: 10,
+                borderLength: 30,
+                borderWidth: 10,
+                cutOutSize: 300,
+              ),
+            )));
   }
 }

--- a/ios/Classes/QRView.swift
+++ b/ios/Classes/QRView.swift
@@ -66,7 +66,9 @@ public class QRView:NSObject,FlutterPlatformView {
         previewView.frame = CGRect(x: 0, y: 0, width: width, height: height)
 
         if let sc: MTBBarcodeScanner = scanner {
-           sc.previewLayer.frame = previewView.bounds;
+            if let previewLayer = sc.previewLayer {
+                previewLayer.frame = previewView.bounds;
+            }
         } else {
             scanner = MTBBarcodeScanner(previewView: previewView)
             MTBBarcodeScanner.requestCameraPermission(success: isCameraAvailable)

--- a/ios/Classes/QRView.swift
+++ b/ios/Classes/QRView.swift
@@ -63,9 +63,14 @@ public class QRView:NSObject,FlutterPlatformView {
     }
     
     func setDimensions(width: Double, height: Double) -> Void {
-       previewView.frame = CGRect(x: 0, y: 0, width: width, height: height)
-       scanner = MTBBarcodeScanner(previewView: previewView)
-       MTBBarcodeScanner.requestCameraPermission(success: isCameraAvailable)
+        previewView.frame = CGRect(x: 0, y: 0, width: width, height: height)
+
+        if let sc: MTBBarcodeScanner = scanner {
+           sc.previewLayer.frame = previewView.bounds;
+        } else {
+            scanner = MTBBarcodeScanner(previewView: previewView)
+            MTBBarcodeScanner.requestCameraPermission(success: isCameraAvailable)
+        }
     }
     
     func flipCamera(){

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -97,11 +97,7 @@ class _CreationParams {
 class QRViewController {
   QRViewController._(int id, GlobalKey qrKey)
       : _channel = MethodChannel('net.touchcapture.qr.flutterqr/qrview_$id') {
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
-      final RenderBox renderBox = qrKey.currentContext.findRenderObject();
-      _channel.invokeMethod('setDimensions',
-          {'width': renderBox.size.width, 'height': renderBox.size.height});
-    }
+    updateDimensions(qrKey);
     _channel.setMethodCallHandler(
       (call) async {
         switch (call.method) {
@@ -141,5 +137,13 @@ class QRViewController {
 
   void dispose() {
     _scanUpdateController.close();
+  }
+
+  void updateDimensions(GlobalKey key) {
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      final RenderBox renderBox =  key.currentContext.findRenderObject();
+      _channel.invokeMethod('setDimensions',
+          {'width': renderBox.size.width, 'height': renderBox.size.height});
+    }
   }
 }

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -141,7 +141,7 @@ class QRViewController {
 
   void updateDimensions(GlobalKey key) {
     if (defaultTargetPlatform == TargetPlatform.iOS) {
-      final RenderBox renderBox =  key.currentContext.findRenderObject();
+      final RenderBox renderBox = key.currentContext.findRenderObject();
       _channel.invokeMethod('setDimensions',
           {'width': renderBox.size.width, 'height': renderBox.size.height});
     }


### PR DESCRIPTION
The issue happens because MTBBarcodeScanner automatically handles rotation.
See https://github.com/mikebuss/MTBBarcodeScanner/blob/aecff1571f41dd69b6898b850c9a978da85a5054/Classes/ios/Scanners/MTBBarcodeScanner.m\#L465

The fix is to detect Flutter QrView size change and adjust scanner's layout frame on iOS

Potentially fixes #34, #87 and #112