### PR TITLE
More state management. Async Return Values. Selectable Barcode types and much more.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,7 @@ var FrontCameraIsActive = controller.activeCamera == Camera.FrontCamera
 ```
 
 ## dispose
-Turn off flash automatically if you call dispose
-```dart
-QRView(
-      turnFlashOffOnDispose: true,
-  ),
-```
+If the view gets disposed, the flash and camera automatically shutdown.
 
 
 

--- a/README.md
+++ b/README.md
@@ -105,27 +105,81 @@ In order to use this plugin, add the following to your Info.plist file:
 <string>This app needs camera access to scan QR codes</string>
 ```
 
+## Get a callback if camera permissions are set
+```
+QRView(
+      onPermissionSet: (QRViewController controller, bool permission){
+      },
+    ),
+```
+
+## Call native alert dialog (Android and IOS) if you dont have permissions
+```dart
+controller.showNativeAlertDialog();
+```
+
+## Call native alert dialog automatically if no permission is granted
+```dart
+QRView(
+      showNativeAlertDialog: true, 
+    ),
+```
+
 ## Flip Camera (Back/Front)
 The default camera is the back camera.
 ```dart
-controller.flipCamera();
+await controller.flipCamera();
 ```
 
 ## Flash (Off/On)
 By default, flash is OFF.
 ```dart
-controller.toggleFlash();
+await controller.toggleFlash();
 ```
 
 ## Resume/Pause
 Pause camera stream and scanner.
 ```dart
-controller.pause();
+await controller.pause();
 ```
 Resume camera stream and scanner.
 ```dart
-controller.resume();
+await controller.resume();
 ```
+
+## Controller
+Most controller methods return `ReturnStatus`.
+Its defined as
+```dart
+enum ReturnStatus { Success, Failed }
+```
+If you want to get a bool from the returned object just use the `asBool` Method like this:
+```dart
+if((await controller.resume()).asBool){
+...
+}
+```
+
+You can also get the SystemFeatures from the controller:
+- hasFlash
+- hasBackCamera
+- hasFrontCamera 
+```dart
+controller.systemFeatures.hasBackCamera
+```
+
+To get the active camera (front or back):
+var backCameraIsActive = controller.activeCamera == Camera.BackCamera
+var FrontCameraIsActive = controller.activeCamera == Camera.FrontCamera
+
+## dispose
+Turn off flash automatically if you call dispose
+```dart
+QRView(
+      turnFlashOffOnDispose: true,
+  ),
+```
+
 
 
 # SDK

--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ QRView(
     ),
 ```
 
+## Set allowed Barcode Types
+```dart
+controller.setAllowedBarcodeTypes([BarcodeTypes.ean8, BarcodeTypes.ean13]);
+```
+
 ## Flip Camera (Back/Front)
 The default camera is the back camera.
 ```dart
@@ -169,8 +174,10 @@ controller.systemFeatures.hasBackCamera
 ```
 
 To get the active camera (front or back):
+```dart
 var backCameraIsActive = controller.activeCamera == Camera.BackCamera
 var FrontCameraIsActive = controller.activeCamera == Camera.FrontCamera
+```
 
 ## dispose
 Turn off flash automatically if you call dispose

--- a/android/src/main/kotlin/net/touchcapture/qr/flutterqr/FlutterQrPlugin.kt
+++ b/android/src/main/kotlin/net/touchcapture/qr/flutterqr/FlutterQrPlugin.kt
@@ -1,24 +1,86 @@
 package net.touchcapture.qr.flutterqr
 
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import io.flutter.plugin.common.PluginRegistry
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
 class FlutterQrPlugin : MethodCallHandler {
+    private lateinit var applicationContext: Context
+    private lateinit var channel: MethodChannel
+    private val listener = CameraRequestPermissionsListener()
+
+    private fun onAttachedToEngine(applicationContext: Context, messenger: BinaryMessenger) {
+        this.applicationContext = applicationContext
+        channel = MethodChannel(messenger, "net.touchcapture.qr.flutterqr/qrview")
+        channel.setMethodCallHandler(this)
+    }
+
     companion object {
+        lateinit var registrar: Registrar
+        private var activity: Activity? = null
+
         @JvmStatic
         fun registerWith(registrar: Registrar) {
+            val instance = FlutterQrPlugin()
             registrar
                     .platformViewRegistry()
                     .registerViewFactory(
                             "net.touchcapture.qr.flutterqr/qrview", QRViewFactory(registrar))
+            this.registrar = registrar
+            this.activity = registrar.activity()
+            instance.onAttachedToEngine(registrar.context(), registrar.messenger())
+            registrar.addRequestPermissionsResultListener(instance.listener)
+        }
+    }
+
+    private inner class CameraRequestPermissionsListener : PluginRegistry.RequestPermissionsResultListener {
+        var result: Result? = null
+
+        override fun onRequestPermissionsResult(id: Int, permissions: Array<String>, grantResults: IntArray): Boolean {
+            if (result == null) {
+                return true
+            }
+            if (id == QRView.CAMERA_REQUEST_ID && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                result?.success(true)
+                result = null
+                return true
+            }
+            result?.success(false)
+            result = null
+            return false
+        }
+    }
+
+    private fun requestPermissions(result: Result) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
+                activity?.checkSelfPermission(Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
+            result.success(true)
+        } else {
+            listener.result = result
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                activity?.requestPermissions(
+                        arrayOf(Manifest.permission.CAMERA),
+                        QRView.CAMERA_REQUEST_ID)
+            } else {
+                result.success(false)
+            }
         }
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
         when {
             call.method == "getPlatformVersion" -> result.success("Android ${android.os.Build.VERSION.RELEASE}")
+            call.method == "requestPermissions" -> requestPermissions(result)
             else -> result.notImplemented()
         }
     }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8=true

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -8,16 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		72CA4F8FC83C02C1B0C5292A /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D115C5DD3945F9758AB33CE2 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; };
 		9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
-		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
-		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -209,10 +205,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
-				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
-				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
-				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -38,11 +38,13 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		32CC770342BC3A6BBD4EB539 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		8AAD99CC72ADFE9F7EDF2941 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		9740EEBA1CF902C7004384FC /* Flutter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Flutter.framework; path = Flutter/Flutter.framework; sourceTree = "<group>"; };
@@ -52,6 +54,7 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D115C5DD3945F9758AB33CE2 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E689C646D7E5252974C242EA /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,6 +74,9 @@
 		0972BCF1757D16A75C3EC240 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				8AAD99CC72ADFE9F7EDF2941 /* Pods-Runner.debug.xcconfig */,
+				32CC770342BC3A6BBD4EB539 /* Pods-Runner.release.xcconfig */,
+				E689C646D7E5252974C242EA /* Pods-Runner.profile.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -174,6 +180,7 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = HBG67S3ZNA;
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
@@ -253,17 +260,13 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/MTBBarcodeScanner/MTBBarcodeScanner.framework",
 				"${BUILT_PRODUCTS_DIR}/qr_code_scanner/qr_code_scanner.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MTBBarcodeScanner.framework",
@@ -271,7 +274,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
@@ -382,7 +385,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = HBG67S3ZNA;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -394,7 +397,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = net.touch.capture;
+				PRODUCT_BUNDLE_IDENTIFIER = "dev.luna-cloud.test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
@@ -522,7 +525,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = HBG67S3ZNA;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -534,7 +537,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = net.touch.capture;
+				PRODUCT_BUNDLE_IDENTIFIER = "dev.luna-cloud.test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -553,7 +556,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = HBG67S3ZNA;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -565,7 +568,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = net.touch.capture;
+				PRODUCT_BUNDLE_IDENTIFIER = "dev.luna-cloud.test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "dev.luna-cloud.test";
+				PRODUCT_BUNDLE_IDENTIFIER = net.touch.capture;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
@@ -529,7 +529,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "dev.luna-cloud.test";
+				PRODUCT_BUNDLE_IDENTIFIER = net.touch.capture;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -560,7 +560,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "dev.luna-cloud.test";
+				PRODUCT_BUNDLE_IDENTIFIER = net.touch.capture;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
+	<key>PreviewsEnabled</key>
+	<false/>
 </dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,8 +34,8 @@ class _QRViewExampleState extends State<QRViewExample> {
             child: QRView(
               key: qrKey,
               onQRViewCreated: _onQRViewCreated,
-              onPermissionSet: (controller, permission){
-                if(!permission) {
+              onPermissionSet: (controller, permission) {
+                if (!permission) {
                   controller.showNativeAlertDialog();
                 }
               },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,6 +34,11 @@ class _QRViewExampleState extends State<QRViewExample> {
             child: QRView(
               key: qrKey,
               onQRViewCreated: _onQRViewCreated,
+              onPermissionSet: (controller, permission){
+                if(!permission) {
+                  controller.showNativeAlertDialog();
+                }
+              },
               overlay: QrScannerOverlayShape(
                 borderColor: Colors.red,
                 borderRadius: 10,

--- a/ios/Classes/QRView.swift
+++ b/ios/Classes/QRView.swift
@@ -46,7 +46,10 @@ public class QRView:NSObject,FlutterPlatformView {
                     if let codes = codes {
                         for code in codes {
                             guard let stringValue = code.stringValue else { continue }
-                            if self?.allowedBarcodeTypes.count == 0 || self?.allowedBarcodeTypes.contains(code.type){
+                            if self == nil{
+                                continue
+                            }
+                            else if self!.allowedBarcodeTypes.count == 0 || self!.allowedBarcodeTypes.contains(code.type){
                                 self?.channel.invokeMethod("onRecognizeQR", arguments: stringValue)
                             }
                         }

--- a/ios/Classes/QRView.swift
+++ b/ios/Classes/QRView.swift
@@ -42,12 +42,12 @@ public class QRView:NSObject,FlutterPlatformView {
                 NSLog("firing permission")
                 self.channel.invokeMethod("onPermissionSet", arguments: true)
                 NSLog("permission fired")
-                try scanner?.startScanning(resultBlock: { codes in
+                try scanner?.startScanning(resultBlock: { [weak self] codes in
                     if let codes = codes {
                         for code in codes {
                             guard let stringValue = code.stringValue else { continue }
-                            if self.allowedBarcodeTypes.count == 0 || self.allowedBarcodeTypes.contains(code.type){
-                                self.channel.invokeMethod("onRecognizeQR", arguments: stringValue)
+                            if self?.allowedBarcodeTypes.count == 0 || self?.allowedBarcodeTypes.contains(code.type){
+                                self?.channel.invokeMethod("onRecognizeQR", arguments: stringValue)
                             }
                         }
                     }

--- a/ios/Classes/SwiftFlutterQrPlugin.swift
+++ b/ios/Classes/SwiftFlutterQrPlugin.swift
@@ -2,7 +2,7 @@ import Flutter
 import UIKit
 import MTBBarcodeScanner
 
-public class SwiftFlutterQrPlugin: NSObject, FlutterPlugin, FlutterStreamHandler{
+public class SwiftFlutterQrPlugin: NSObject, FlutterPlugin{
   var channel: FlutterMethodChannel
   var factory: QRViewFactory
 
@@ -10,7 +10,8 @@ public class SwiftFlutterQrPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
     self.factory = QRViewFactory(withRegistrar: registrar)
     registrar.register(factory, withId: "net.touchcapture.qr.flutterqr/qrview")
     channel = FlutterMethodChannel(name: "net.touchcapture.qr.flutterqr/qrview", binaryMessenger: registrar.messenger())
-    channel.setMethodCallHandler(self)
+    super.init()
+    channel.setMethodCallHandler(self.onMethodCalled)
   }
     
   public static func register(with registrar: FlutterPluginRegistrar) {
@@ -26,9 +27,9 @@ public class SwiftFlutterQrPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
     }
     
   public func onMethodCalled(_ call: FlutterMethodCall, result: @escaping FlutterResult){
-        switch call.method {
+      switch call.method {
         case "requestPermissions":
-            MTBBarcodeScanner.requestCameraPermission(success: (success:Bool)->isCameraAvailable(success, result))
+            MTBBarcodeScanner.requestCameraPermission(success: {(success:Bool) in self.isCameraAvailable(success, result)})
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/ios/Classes/SwiftFlutterQrPlugin.swift
+++ b/ios/Classes/SwiftFlutterQrPlugin.swift
@@ -1,16 +1,37 @@
 import Flutter
 import UIKit
+import MTBBarcodeScanner
 
-public class SwiftFlutterQrPlugin: NSObject, FlutterPlugin {
-
+public class SwiftFlutterQrPlugin: NSObject, FlutterPlugin, FlutterStreamHandler{
+  var channel: FlutterMethodChannel
   var factory: QRViewFactory
+
   public init(with registrar: FlutterPluginRegistrar) {
     self.factory = QRViewFactory(withRegistrar: registrar)
     registrar.register(factory, withId: "net.touchcapture.qr.flutterqr/qrview")
+    channel = FlutterMethodChannel(name: "net.touchcapture.qr.flutterqr/qrview", binaryMessenger: registrar.messenger())
+    channel.setMethodCallHandler(self)
   }
     
   public static func register(with registrar: FlutterPluginRegistrar) {
     registrar.addApplicationDelegate(SwiftFlutterQrPlugin(with: registrar))
+  }
+    
+    func isCameraAvailable(_ success: Bool, _ result: FlutterResult) -> Void {
+        if success {
+            result(true)
+        } else {
+            result(false)
+        }
+    }
+    
+  public func onMethodCalled(_ call: FlutterMethodCall, result: @escaping FlutterResult){
+        switch call.method {
+        case "requestPermissions":
+            MTBBarcodeScanner.requestCameraPermission(success: (success:Bool)->isCameraAvailable(success, result))
+        default:
+            result(FlutterMethodNotImplemented)
+        }
   }
   
   public func applicationDidEnterBackground(_ application: UIApplication) {

--- a/lib/qr_code_scanner.dart
+++ b/lib/qr_code_scanner.dart
@@ -1,2 +1,6 @@
 export 'src/qr_code_scanner.dart';
 export 'src/qr_scanner_overlay_shape.dart';
+export 'src/types/barcode.dart';
+export 'src/types/camera.dart';
+export 'src/types/features.dart';
+export 'src/types/status.dart';

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -130,7 +130,7 @@ class QRViewController {
               } else {
                 _hasPermissions = false;
                 if (showNativeAlertDialogOnError) {
-                  showNativeAlertDialog();
+                  await showNativeAlertDialog();
                 }
               }
               if (onPermissionSet != null) {

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -3,20 +3,30 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:qr_code_scanner/qr_code_scanner.dart';
 
 typedef QRViewCreatedCallback = void Function(QRViewController);
+typedef PermissionSetCallback = void Function(QRViewController, bool);
 
 class QRView extends StatefulWidget {
   const QRView({
     @required Key key,
     @required this.onQRViewCreated,
+    this.onPermissionSet,
+    this.turnFlashOffOnDispose = true,
+    this.showNativeAlertDialog = false,
     this.overlay,
-  })  : assert(key != null),
+  })
+      : assert(key != null),
         assert(onQRViewCreated != null),
+        assert(showNativeAlertDialog != null),
+        assert(turnFlashOffOnDispose != null),
         super(key: key);
 
   final QRViewCreatedCallback onQRViewCreated;
-
+  final PermissionSetCallback onPermissionSet;
+  final bool turnFlashOffOnDispose;
+  final bool showNativeAlertDialog;
   final ShapeBorder overlay;
 
   @override
@@ -69,7 +79,12 @@ class _QRViewState extends State<QRView> {
     if (widget.onQRViewCreated == null) {
       return;
     }
-    widget.onQRViewCreated(QRViewController._(id, widget.key));
+    widget.onQRViewCreated(QRViewController._(
+        id,
+        widget.key,
+        widget.onPermissionSet,
+        widget.showNativeAlertDialog,
+        widget.turnFlashOffOnDispose));
   }
 }
 
@@ -94,52 +109,161 @@ class _CreationParams {
   }
 }
 
+enum Camera {
+  BackCamera,
+  FrontCamera,
+}
+
+enum ReturnStatus { Success, Failed }
+
+extension ReturnStatusExtension on ReturnStatus {
+  bool asBool() {
+    return this == ReturnStatus.Success;
+  }
+}
+
+class SystemFeatures {
+  SystemFeatures(this.hasFlash, this.hasBackCamera, this.hasFrontCamera);
+
+  factory SystemFeatures.fromJson(Map<String, dynamic> features) =>
+      SystemFeatures(
+          features['hasFlash'] ?? false,
+          features['hasBackCamera'] ?? false,
+          features['hasFrontCamera'] ?? false);
+
+  final bool hasFlash;
+  final bool hasFrontCamera;
+  final bool hasBackCamera;
+}
+
 class QRViewController {
-  QRViewController._(int id, GlobalKey qrKey)
+  QRViewController._(int id,
+      GlobalKey qrKey,
+      PermissionSetCallback onPermissionSet,
+      bool showNativeAlertDialogOnError,
+      this._turnFlashOffOnDispose,)
       : _channel = MethodChannel('net.touchcapture.qr.flutterqr/qrview_$id') {
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
-      final RenderBox renderBox = qrKey.currentContext.findRenderObject();
-      _channel.invokeMethod('setDimensions',
-          {'width': renderBox.size.width, 'height': renderBox.size.height});
-    }
     _channel.setMethodCallHandler(
-      (call) async {
+          (call) async {
         switch (call.method) {
           case scanMethodCall:
             if (call.arguments != null) {
               _scanUpdateController.sink.add(call.arguments.toString());
             }
+          break;
+          case permissionMethodCall:
+            await getSystemFeatures(); // if we have no permission all features will not be avaible
+            print(call.arguments.toString());
+            print(onPermissionSet);
+            if (call.arguments != null && onPermissionSet != null) {
+              if (call.arguments as bool) {
+                _cameraActive = true;
+              }
+              if (showNativeAlertDialogOnError) {
+                showNativeAlertDialog();
+              }
+              onPermissionSet(this, call.arguments as bool);
+            }
+          break;
         }
       },
     );
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      final RenderBox renderBox = qrKey.currentContext.findRenderObject();
+      _channel.invokeMethod('setDimensions',
+          {'width': renderBox.size.width, 'height': renderBox.size.height});
+    }
   }
 
+  final bool _turnFlashOffOnDispose;
   static const scanMethodCall = 'onRecognizeQR';
+  static const permissionMethodCall = 'onPermissionSet';
 
   final MethodChannel _channel;
 
   final StreamController<String> _scanUpdateController =
-      StreamController<String>();
+  StreamController<String>();
 
   Stream<String> get scannedDataStream => _scanUpdateController.stream;
 
-  void flipCamera() {
-    _channel.invokeMethod('flipCamera');
+  bool _flashActive = false;
+
+  bool _cameraActive = false;
+
+  int _activeCamera = 0;
+
+  SystemFeatures _features;
+
+  SystemFeatures get systemFeatures => _features;
+
+  bool get cameraActive => _cameraActive;
+
+  bool get flashActive => _flashActive;
+
+  Camera get activeCamera =>
+      _activeCamera == null ? null : Camera.values[_activeCamera];
+
+  Future<ReturnStatus> flipCamera() async {
+    try {
+      _activeCamera = await _channel.invokeMethod('flipCamera') as int;
+      return ReturnStatus.Success;
+    } on PlatformException catch (e) {
+      return ReturnStatus.Failed;
+    }
   }
 
-  void toggleFlash() {
-    _channel.invokeMethod('toggleFlash');
+  Future<ReturnStatus> toggleFlash() async {
+    try {
+      _flashActive = await _channel.invokeMethod('toggleFlash') as bool;
+      return ReturnStatus.Success;
+    } on PlatformException catch (e) {
+      return ReturnStatus.Failed;
+    }
   }
 
-  void pauseCamera() {
-    _channel.invokeMethod('pauseCamera');
+  Future<ReturnStatus> pauseCamera() async {
+    try {
+      var cameraPaused = await _channel.invokeMethod('pauseCamera') as bool;
+      _cameraActive = !cameraPaused;
+      return ReturnStatus.Success;
+    } on PlatformException catch (e) {
+      return ReturnStatus.Failed;
+    }
   }
 
-  void resumeCamera() {
-    _channel.invokeMethod('resumeCamera');
+  Future<ReturnStatus> resumeCamera() async {
+    try {
+      _cameraActive = await _channel.invokeMethod('resumeCamera');
+      return ReturnStatus.Success;
+    } on PlatformException catch (e) {
+      return ReturnStatus.Failed;
+    }
+  }
+
+  Future<ReturnStatus> showNativeAlertDialog() async {
+    try {
+      await _channel.invokeMethod('showNativeAlertDialog');
+      return ReturnStatus.Success;
+    } on PlatformException catch (e) {
+      return ReturnStatus.Failed;
+    }
+  }
+
+  Future<SystemFeatures> getSystemFeatures() async {
+    try {
+      var features = await _channel.invokeMapMethod<String, dynamic>('getSystemFeatures');
+      _features = SystemFeatures.fromJson(features);
+      _activeCamera = features['activeCamera'];
+      return _features;
+    } on PlatformException catch (e) {
+      return null;
+    }
   }
 
   void dispose() {
+    if (_features.hasFlash && _turnFlashOffOnDispose && _flashActive) {
+      _channel.invokeMethod('toggleFlash');
+    }
     _scanUpdateController.close();
   }
 }

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -134,7 +134,9 @@ class QRViewController {
             if (args != null) {
               if (args as bool) {
                 _cameraActive = true;
+                _hasPermissions = true;
               } else {
+                _hasPermissions = false;
                 if (showNativeAlertDialogOnError) {
                   showNativeAlertDialog();
                 }
@@ -174,6 +176,10 @@ class QRViewController {
   SystemFeatures _features;
 
   SystemFeatures get systemFeatures => _features;
+
+  bool _hasPermissions;
+
+  bool get hasPermissions => _hasPermissions;
 
   bool get cameraActive => _cameraActive;
 

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -17,7 +17,8 @@ class QRView extends StatefulWidget {
 
   static Future<bool> requestCameraPermission() async {
     try {
-      return await _channel.invokeMethod('requestPermissions');
+      var permissions =  await _channel.invokeMethod('requestPermissions');
+      return permissions;
     } on PlatformException {
       return false;
     }

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -150,7 +150,7 @@ class QRViewController {
             if (call.arguments != null) {
               _scanUpdateController.sink.add(call.arguments.toString());
             }
-          break;
+            break;
           case permissionMethodCall:
             await getSystemFeatures(); // if we have no permission all features will not be avaible
             print(call.arguments.toString());
@@ -164,7 +164,7 @@ class QRViewController {
               }
               onPermissionSet(this, call.arguments as bool);
             }
-          break;
+            break;
         }
       },
     );
@@ -251,7 +251,8 @@ class QRViewController {
 
   Future<SystemFeatures> getSystemFeatures() async {
     try {
-      var features = await _channel.invokeMapMethod<String, dynamic>('getSystemFeatures');
+      var features = await _channel.invokeMapMethod<String, dynamic>(
+          'getSystemFeatures');
       _features = SystemFeatures.fromJson(features);
       _activeCamera = features['activeCamera'];
       return _features;
@@ -262,7 +263,7 @@ class QRViewController {
 
   void dispose() {
     if (_features.hasFlash && _turnFlashOffOnDispose && _flashActive) {
-      _channel.invokeMethod('toggleFlash');
+      toggleFlash();
     }
     _scanUpdateController.close();
   }

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -12,17 +12,17 @@ import 'types/status.dart';
 typedef QRViewCreatedCallback = void Function(QRViewController);
 typedef PermissionSetCallback = void Function(QRViewController, bool);
 
-final _channel = MethodChannel('net.touchcapture.qr.flutterqr/qrview');
-
-Future<bool> requestCameraPermission() async {
-  try {
-    return await _channel.invokeMethod('requestPermissions');
-  } on PlatformException {
-    return false;
-  }
-}
-
 class QRView extends StatefulWidget {
+  static final _channel = MethodChannel('net.touchcapture.qr.flutterqr/qrview');
+
+  static Future<bool> requestCameraPermission() async {
+    try {
+      return await _channel.invokeMethod('requestPermissions');
+    } on PlatformException {
+      return false;
+    }
+  }
+
   const QRView({
     @required Key key,
     @required this.onQRViewCreated,

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -17,18 +17,15 @@ class QRView extends StatefulWidget {
     @required Key key,
     @required this.onQRViewCreated,
     this.onPermissionSet,
-    this.turnFlashOffOnDispose = true,
     this.showNativeAlertDialog = false,
     this.overlay,
   })  : assert(key != null),
         assert(onQRViewCreated != null),
         assert(showNativeAlertDialog != null),
-        assert(turnFlashOffOnDispose != null),
         super(key: key);
 
   final QRViewCreatedCallback onQRViewCreated;
   final PermissionSetCallback onPermissionSet;
-  final bool turnFlashOffOnDispose;
   final bool showNativeAlertDialog;
   final ShapeBorder overlay;
 
@@ -86,8 +83,7 @@ class _QRViewState extends State<QRView> {
         id,
         widget.key,
         widget.onPermissionSet,
-        widget.showNativeAlertDialog,
-        widget.turnFlashOffOnDispose));
+        widget.showNativeAlertDialog));
   }
 }
 
@@ -118,7 +114,6 @@ class QRViewController {
     GlobalKey qrKey,
     PermissionSetCallback onPermissionSet,
     bool showNativeAlertDialogOnError,
-    this._turnFlashOffOnDispose,
   ) : _channel = MethodChannel('net.touchcapture.qr.flutterqr/qrview_$id') {
     _channel.setMethodCallHandler(
       (call) async {
@@ -156,7 +151,6 @@ class QRViewController {
     }
   }
 
-  final bool _turnFlashOffOnDispose;
   static const scanMethodCall = 'onRecognizeQR';
   static const permissionMethodCall = 'onPermissionSet';
 
@@ -257,9 +251,6 @@ class QRViewController {
   }
 
   void dispose() {
-    if (_features.hasFlash && _turnFlashOffOnDispose && _flashActive) {
-      toggleFlash();
-    }
     _scanUpdateController.close();
   }
 }

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:qr_code_scanner/qr_code_scanner.dart';
 
 import 'types/barcode.dart';
 import 'types/camera.dart';
@@ -186,18 +185,18 @@ class QRViewController {
   Future<ReturnStatus> flipCamera() async {
     try {
       _activeCamera = await _channel.invokeMethod('flipCamera') as int;
-      return ReturnStatus.Success;
-    } on PlatformException catch (e) {
-      return ReturnStatus.Failed;
+      return ReturnStatus.success;
+    } on PlatformException {
+      return ReturnStatus.failed;
     }
   }
 
   Future<ReturnStatus> toggleFlash() async {
     try {
       _flashActive = await _channel.invokeMethod('toggleFlash') as bool;
-      return ReturnStatus.Success;
-    } on PlatformException catch (e) {
-      return ReturnStatus.Failed;
+      return ReturnStatus.success;
+    } on PlatformException {
+      return ReturnStatus.failed;
     }
   }
 
@@ -205,37 +204,37 @@ class QRViewController {
     try {
       var cameraPaused = await _channel.invokeMethod('pauseCamera') as bool;
       _cameraActive = !cameraPaused;
-      return ReturnStatus.Success;
-    } on PlatformException catch (e) {
-      return ReturnStatus.Failed;
+      return ReturnStatus.success;
+    } on PlatformException {
+      return ReturnStatus.failed;
     }
   }
 
   Future<ReturnStatus> resumeCamera() async {
     try {
       _cameraActive = await _channel.invokeMethod('resumeCamera');
-      return ReturnStatus.Success;
-    } on PlatformException catch (e) {
-      return ReturnStatus.Failed;
+      return ReturnStatus.success;
+    } on PlatformException {
+      return ReturnStatus.failed;
     }
   }
 
   Future<ReturnStatus> showNativeAlertDialog() async {
     try {
       await _channel.invokeMethod('showNativeAlertDialog');
-      return ReturnStatus.Success;
-    } on PlatformException catch (e) {
-      return ReturnStatus.Failed;
+      return ReturnStatus.success;
+    } on PlatformException {
+      return ReturnStatus.failed;
     }
   }
 
   Future<ReturnStatus> setAllowedBarcodeTypes(List<BarcodeTypes> list) async {
     try {
       await _channel.invokeMethod('setAllowedBarcodeFormats',
-          list?.map((e) => e.asInt()).toList() ?? []);
-      return ReturnStatus.Success;
-    } on PlatformException catch (e) {
-      return ReturnStatus.Failed;
+          list?.map((e) => e.asInt())?.toList() ?? []);
+      return ReturnStatus.success;
+    } on PlatformException {
+      return ReturnStatus.failed;
     }
   }
 
@@ -246,7 +245,7 @@ class QRViewController {
       _features = SystemFeatures.fromJson(features);
       _activeCamera = features['activeCamera'];
       return _features;
-    } on PlatformException catch (e) {
+    } on PlatformException {
       return null;
     }
   }

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -80,10 +80,7 @@ class _QRViewState extends State<QRView> {
       return;
     }
     widget.onQRViewCreated(QRViewController._(
-        id,
-        widget.key,
-        widget.onPermissionSet,
-        widget.showNativeAlertDialog));
+        id, widget.key, widget.onPermissionSet, widget.showNativeAlertDialog));
   }
 }
 

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -12,6 +12,16 @@ import 'types/status.dart';
 typedef QRViewCreatedCallback = void Function(QRViewController);
 typedef PermissionSetCallback = void Function(QRViewController, bool);
 
+final _channel = MethodChannel('net.touchcapture.qr.flutterqr/qrview');
+
+Future<bool> requestCameraPermission() async {
+  try {
+    return await _channel.invokeMethod('requestPermissions');
+  } on PlatformException {
+    return false;
+  }
+}
+
 class QRView extends StatefulWidget {
   const QRView({
     @required Key key,

--- a/lib/src/types/barcode.dart
+++ b/lib/src/types/barcode.dart
@@ -1,0 +1,19 @@
+enum BarcodeTypes {
+  aztec,
+  code128,
+  code39,
+  code93,
+  dataMatrix,
+  ean13,
+  ean8,
+  interleaved2of5,
+  pdf417,
+  qr,
+  upce,
+}
+
+extension BarcodeTypesExtension on BarcodeTypes {
+  int asInt() {
+    return index;
+  }
+}

--- a/lib/src/types/camera.dart
+++ b/lib/src/types/camera.dart
@@ -1,4 +1,4 @@
 enum Camera {
-  BackCamera,
-  FrontCamera,
+  backCamera,
+  frontCamera,
 }

--- a/lib/src/types/camera.dart
+++ b/lib/src/types/camera.dart
@@ -1,0 +1,4 @@
+enum Camera {
+  BackCamera,
+  FrontCamera,
+}

--- a/lib/src/types/features.dart
+++ b/lib/src/types/features.dart
@@ -1,0 +1,13 @@
+class SystemFeatures {
+  SystemFeatures(this.hasFlash, this.hasBackCamera, this.hasFrontCamera);
+
+  factory SystemFeatures.fromJson(Map<String, dynamic> features) =>
+      SystemFeatures(
+          features['hasFlash'] ?? false,
+          features['hasBackCamera'] ?? false,
+          features['hasFrontCamera'] ?? false);
+
+  final bool hasFlash;
+  final bool hasFrontCamera;
+  final bool hasBackCamera;
+}

--- a/lib/src/types/status.dart
+++ b/lib/src/types/status.dart
@@ -1,7 +1,7 @@
-enum ReturnStatus { Success, Failed }
+enum ReturnStatus { success, failed }
 
 extension ReturnStatusExtension on ReturnStatus {
   bool asBool() {
-    return this == ReturnStatus.Success;
+    return this == ReturnStatus.success;
   }
 }

--- a/lib/src/types/status.dart
+++ b/lib/src/types/status.dart
@@ -1,0 +1,7 @@
+enum ReturnStatus { Success, Failed }
+
+extension ReturnStatusExtension on ReturnStatus {
+  bool asBool() {
+    return this == ReturnStatus.Success;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://juliuscanute.com
 repository: https://github.com/juliuscanute/qr_code_scanner
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.6.0 <3.0.0"
   flutter: ^1.10.0
 
 dependencies:


### PR DESCRIPTION
With this fork you have more functionality (which was available but not exposed to flutter user):

- State management. Check if your flash is on. controller.flashActive. Check if the users phone has a Backcamera: controller.systemfeatures.hasBackCamera and much more ;)
- Every native call now returns a async function which returns Success or an Error value (Check Class ReturnStatus).
- its possible to turn off/on some functionality. you can turn off/on to show the Native Error dialog when no permission is given. (Native error dialog is also available in android) Or you can disable the flash on controller.dispose
- its possible to call your NativeErrorDialog when you need it (controller.showNativeAlertDialog())
- Its possible to set allowed Barcode types. (controller.setAllowedBarcodeTypes) Only these one will get returned to flutter code. <--- saw that a pull request for that one is appreciated
- a callback to flutter when the permission is handled in the native part. In the callback you can see which permission was given and now you can do more things :)

fixes #126
fixes #107
fixes #103
fixes #93


I forgot to mention that this should not break the current API.