### PR TITLE
Close camera when view dispose on iOS

### DIFF
--- a/ios/Classes/QRView.swift
+++ b/ios/Classes/QRView.swift
@@ -99,4 +99,8 @@ public class QRView:NSObject,FlutterPlatformView {
             }
         }
     }
+
+    deinit {
+        scanner?.stopScanning()
+    }
 }


### PR DESCRIPTION
On iOS 14, it can check the camera status easily. So I found that camera didn't close when we leave the qr code scanner view.