### PR TITLE
fix 相机不会关闭的问题

### DIFF
--- a/ios/Classes/QRView.swift
+++ b/ios/Classes/QRView.swift
@@ -54,6 +54,9 @@ public class QRView:NSObject,FlutterPlatformView {
                     self?.pauseCamera()
                 case "resumeCamera":
                     self?.resumeCamera()
+                case "stopScanning":
+                // 添加关闭相机方法
+                    self?.scanner?.stopScanning()
                 default:
                     result(FlutterMethodNotImplemented)
                     return

--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -140,6 +140,8 @@ class QRViewController {
   }
 
   void dispose() {
+    // 退出页面后，关闭相机，不然会在iOS14中，bar上一直显示绿点，相机在运行
+    _channel.invokeMethod('stopScanning');
     _scanUpdateController.close();
   }
 }


### PR DESCRIPTION
iOS相机没有调用相机的关闭方法，一直在运行中