### PR TITLE
Properly implement ActivityLifecycleCallbacks public functions

### DIFF
--- a/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
+++ b/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
@@ -39,31 +39,31 @@ class QRView(private val registrar: PluginRegistry.Registrar, id: Int) :
         channel.setMethodCallHandler(this)
         checkAndRequestPermission(null)
         registrar.activity().application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
-            override fun onActivityPaused(p0: Activity?) {
+            override fun onActivityPaused(p0: Activity) {
                 if (p0 == registrar.activity()) {
                     barcodeView?.pause()
                 }
             }
 
-            override fun onActivityResumed(p0: Activity?) {
+            override fun onActivityResumed(p0: Activity) {
                 if (p0 == registrar.activity()) {
                     barcodeView?.resume()
                 }
             }
 
-            override fun onActivityStarted(p0: Activity?) {
+            override fun onActivityStarted(p0: Activity) {
             }
 
-            override fun onActivityDestroyed(p0: Activity?) {
+            override fun onActivityDestroyed(p0: Activity) {
             }
 
-            override fun onActivitySaveInstanceState(p0: Activity?, p1: Bundle?) {
+            override fun onActivitySaveInstanceState(p0: Activity, p1: Bundle) {
             }
 
-            override fun onActivityStopped(p0: Activity?) {
+            override fun onActivityStopped(p0: Activity) {
             }
 
-            override fun onActivityCreated(p0: Activity?, p1: Bundle?) {
+            override fun onActivityCreated(p0: Activity, p1: Bundle?) {
             }
         })
     }


### PR DESCRIPTION
Fixing bug I encountered (Unit defined in android.app.Application.ActivityLifecycleCallbacks)

e: C:\src\flutter.pub-cache\hosted\pub.dartlang.org\qr_code_scanner-0.0.14\android\src\main\kotlin\net\touchcapture\qr\flutterqr\QRView.kt: (41, 77): Object is not abstract and does not implement abstract member public abstract fun onActivityPaused(@nonnull p0: Activity): Unit defined in android.app.Application.ActivityLifecycleCallbacks
e: C:\src\flutter.pub-cache\hosted\pub.dartlang.org\qr_code_scanner-0.0.14\android\src\main\kotlin\net\touchcapture\qr\flutterqr\QRView.kt: (42, 13): 'onActivityPaused' overrides nothing
e: C:\src\flutter.pub-cache\hosted\pub.dartlang.org\qr_code_scanner-0.0.14\android\src\main\kotlin\net\touchcapture\qr\flutterqr\QRView.kt: (48, 13): 'onActivityResumed' overrides nothing
e: C:\src\flutter.pub-cache\hosted\pub.dartlang.org\qr_code_scanner-0.0.14\android\src\main\kotlin\net\touchcapture\qr\flutterqr\QRView.kt: (54, 13): 'onActivityStarted' overrides nothing
e: C:\src\flutter.pub-cache\hosted\pub.dartlang.org\qr_code_scanner-0.0.14\android\src\main\kotlin\net\touchcapture\qr\flutterqr\QRView.kt: (57, 13): 'onActivityDestroyed' overrides nothing
e: C:\src\flutter.pub-cache\hosted\pub.dartlang.org\qr_code_scanner-0.0.14\android\src\main\kotlin\net\touchcapture\qr\flutterqr\QRView.kt: (60, 13): 'onActivitySaveInstanceState' overrides nothing
e: C:\src\flutter.pub-cache\hosted\pub.dartlang.org\qr_code_scanner-0.0.14\android\src\main\kotlin\net\touchcapture\qr\flutterqr\QRView.kt: (63, 13): 'onActivityStopped' overrides nothing
e: C:\src\flutter.pub-cache\hosted\pub.dartlang.org\qr_code_scanner-0.0.14\android\src\main\kotlin\net\touchcapture\qr\flutterqr\QRView.kt: (66, 13): 'onActivityCreated' overrides nothing