### PR TITLE
fix permission bug android

### DIFF
--- a/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
+++ b/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
@@ -102,8 +102,6 @@ class QRView(messenger: BinaryMessenger, id: Int, private val params: HashMap<St
     private fun flipCamera(result: MethodChannel.Result) {
         if (barcodeView == null) {
             return barCodeViewNotSet(result)
-        } else if (!hasCameraPermission()) {
-            checkAndRequestPermission(result)
         } else {
             barcodeView!!.pause()
             val settings = barcodeView!!.cameraSettings
@@ -146,8 +144,6 @@ class QRView(messenger: BinaryMessenger, id: Int, private val params: HashMap<St
     private fun pauseCamera(result: MethodChannel.Result) {
         if (barcodeView == null) {
             return barCodeViewNotSet(result)
-        } else if (!hasCameraPermission()) {
-            checkAndRequestPermission(result)
         } else {
             if (barcodeView!!.isPreviewActive) {
                 isPaused = true
@@ -160,8 +156,6 @@ class QRView(messenger: BinaryMessenger, id: Int, private val params: HashMap<St
     private fun resumeCamera(result: MethodChannel.Result) {
         if (barcodeView == null) {
             return barCodeViewNotSet(result)
-        } else if (!hasCameraPermission()) {
-            checkAndRequestPermission(result)
         } else {
             if (!barcodeView!!.isPreviewActive) {
                 isPaused = false
@@ -203,11 +197,7 @@ class QRView(messenger: BinaryMessenger, id: Int, private val params: HashMap<St
                 barcodeView?.cameraSettings?.requestedCameraId = CameraInfo.CAMERA_FACING_FRONT
             }
         } else {
-            if (hasCameraPermission()) {
-                if (!isPaused) barcodeView!!.resume()
-            } else {
-                checkAndRequestPermission(null)
-            }
+            if (!isPaused) barcodeView!!.resume()
         }
         return barcodeView
     }

--- a/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
+++ b/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
@@ -273,14 +273,17 @@ class QRView(messenger: BinaryMessenger, id: Int, private val params: HashMap<St
     override fun onRequestPermissionsResult( requestCode: Int,
                                              permissions: Array<out String>?,
                                              grantResults: IntArray): Boolean {
-
-        if (requestCode == Shared.CAMERA_REQUEST_ID && grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            permissionGranted = true
-            channel.invokeMethod("onPermissionSet", true)
-            return true
+        if(requestCode == Shared.CAMERA_REQUEST_ID) {
+            if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                permissionGranted = true
+                channel.invokeMethod("onPermissionSet", true)
+                return true
+            } else {
+                permissionGranted = false
+                channel.invokeMethod("onPermissionSet", false)
+                return false
+            }
         }
-        permissionGranted = false
-        channel.invokeMethod("onPermissionSet", false)
         return false
     }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,10 +1,32 @@
+import 'dart:developer';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
 
-void main() => runApp(MaterialApp(home: QRViewExample()));
+void main() => runApp(MaterialApp(home: MyHome()));
+
+class MyHome extends StatelessWidget {
+  const MyHome({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Flutter Demo Home Page')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            Navigator.of(context).push(MaterialPageRoute(
+              builder: (context) => QRViewExample(),
+            ));
+          },
+          child: Text('qrView'),
+        ),
+      ),
+    );
+  }
+}
 
 class QRViewExample extends StatefulWidget {
   @override
@@ -134,6 +156,7 @@ class _QRViewExampleState extends State<QRViewExample> {
           borderLength: 30,
           borderWidth: 10,
           cutOutSize: scanArea),
+      onPermissionSet: (ctrl, p) => _onPermissionSet(context, ctrl, p),
     );
   }
 
@@ -146,6 +169,15 @@ class _QRViewExampleState extends State<QRViewExample> {
         result = scanData;
       });
     });
+  }
+
+  void _onPermissionSet(BuildContext context, QRViewController ctrl, bool p) {
+    log('${DateTime.now().toIso8601String()}_onPermissionSet $p');
+    if (!p) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('no Permission')),
+      );
+    }
   }
 
   @override


### PR DESCRIPTION
add 构建/销毁QRView时的测试。
fix 构建QRView时，onPermissionSet函数多次返回。
fix 销毁QRView时，会展示权限弹窗。
fix 其他请求权限时，onPermissionSet会响应

https://github.com/juliuscanute/qr_code_scanner/issues/305