### PR TITLE
Added desugaring feature

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,11 +34,18 @@ android {
         // minSdkVersion is determined by Native View.
         minSdkVersion 20
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
     buildFeatures {
         viewBinding = true
     }
-
+    compileOptions {
+        // Flag to enable support for the new language APIs
+        coreLibraryDesugaringEnabled true
+        // Sets Java compatibility to Java 8
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
@@ -46,4 +53,5 @@ dependencies {
     implementation('com.journeyapps:zxing-android-embedded:4.1.0') { transitive = false }
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.google.zxing:core:3.4.1'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 }


### PR DESCRIPTION
The goal of this feature is to avoid the following error:

```
Fatal Exception: java.lang.NoSuchMethodError
No interface method sort(Ljava/util/Comparator;)V in class Ljava/util/List; or its super classes (declaration of 'java.util.List' appears in /system/framework/core-libart.jar)
```
By adding the `desugar` feature seems to fix this bug.

Issue reported:
https://github.com/juliuscanute/qr_code_scanner/issues/418