### PR TITLE
Old sdk support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,8 +50,8 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation('com.journeyapps:zxing-android-embedded:4.1.0') { transitive = false }
+    implementation('com.journeyapps:zxing-android-embedded:4.2.0') { transitive = false }
     implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation 'com.google.zxing:core:3.4.1'
+    implementation 'com.google.zxing:core:3.3.0'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,6 +52,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation('com.journeyapps:zxing-android-embedded:4.2.0') { transitive = false }
     implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation 'com.google.zxing:core:3.3.0'
+    implementation 'com.google.zxing:core:3.3.3'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 }


### PR DESCRIPTION
I did some more deep tests and found that https://github.com/juliuscanute/qr_code_scanner/pull/434 was not enough to solve the issue with older sdk (https://github.com/juliuscanute/qr_code_scanner/issues/418);

In the `zxing android embedded` documentation (https://github.com/journeyapps/zxing-android-embedded), they say to downgrade to `3.3.0` core version.

But I have done tests with a more recent core version `3.3.3` and it worked fine in older and news Android SDK;

So the only change need was:
    `implementation 'com.google.zxing:core:3.4.1'`
to
    `implementation 'com.google.zxing:core:3.3.3'`

Adding zxing:core 3.3.3 dependency did the work;

Also, I have upgraded the `zxing-android-embedded` version to `4.2.0`