### PR TITLE
Android permission fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,8 +48,8 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation('com.journeyapps:zxing-android-embedded:4.2.0') { transitive = false }
+    implementation('com.journeyapps:zxing-android-embedded:4.3.0') { transitive = false }
     implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation 'com.google.zxing:core:3.3.3'
+    implementation 'com.google.zxing:core:3.3.0'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 }

--- a/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
+++ b/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
@@ -293,7 +293,9 @@ class QRView(private val context: Context, messenger: BinaryMessenger, private v
                 }
             }
             else -> {
-                result?.error("cameraPermission", "Platform Version to low for camera permission check", null)
+                // We should have permissions on older OS versions
+                permissionGranted = true
+                channel.invokeMethod("onPermissionSet", true)
             }
         }
     }


### PR DESCRIPTION
This is fix for issues #377 and #398.

For lower Android versions than 6, we should allow to use camera, because permission is granted automatically when the app is installing.

I also upgraded ZXing Android Embedded and downgraded ZXing Core according to this point:
https://github.com/journeyapps/zxing-android-embedded#option-1-downgrade-zxingcore-to-330