### PR TITLE
fix #388: ignore throw in permission refuses

### DIFF
--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -233,7 +233,9 @@ class QRViewController {
       return await _channel.invokeMethod(
           'startScan', barcodeFormats?.map((e) => e.asInt()).toList() ?? []);
     } on PlatformException catch (e) {
-      throw CameraException(e.code, e.message);
+      if(e.code != "cameraPermission") {
+        throw CameraException(e.code, e.message);
+      }
     }
   }
 


### PR DESCRIPTION
the error is produced only in IOS, because it does not handle a permission denied exception when the user rejects it manually, but the ```onPermisionSet``` callback is fired correctly, so it will avoid throwing the exception in that case so that it can be handled normally in the callback arranged for it.