### PR TITLE
fix #388: avoid throwing unnecessary exception

### DIFF
--- a/ios/Classes/QRView.swift
+++ b/ios/Classes/QRView.swift
@@ -207,9 +207,6 @@ public class QRView:NSObject,FlutterPlatformView {
                     let scanError = FlutterError(code: "unknown-error", message: "Unable to start scanning", details: error)
                     result(scanError)
                 }
-            } else {
-                let error = FlutterError(code: "cameraPermission", message: "Permission denied to access the camera", details: nil)
-                result(error)
             }
         })
     }


### PR DESCRIPTION
this error is produced only in IOS, since an exception is intentionally returned when the user rejects it manually, but the ```onPermisionSet``` callback is fired correctly, so it will avoid throwing additional the exception in that case so that it can be handled normally in the callback arranged for it. (this behavior is now the same as in android)