### PR TITLE
[web] Catching and silencing "NoSuchMethodError" on get$data that triggers in web releases with jsQR

### DIFF
--- a/lib/src/web/flutter_qr_web.dart
+++ b/lib/src/web/flutter_qr_web.dart
@@ -193,11 +193,16 @@ class _WebQrViewState extends State<WebQrView> {
       });
     }
 
-    final code = jsQR(imgData.data, canvas.width, canvas.height);
-    // ignore: unnecessary_null_comparison
-    if (code != null) {
-      _scanUpdateController
-          .add(Barcode(code.data, BarcodeFormat.qrcode, code.data.codeUnits));
+    try {
+      final code = jsQR(imgData.data, canvas.width, canvas.height);
+      // ignore: unnecessary_null_comparison
+      if (code != null && code.data != null) {
+        _scanUpdateController
+            .add(Barcode(code.data, BarcodeFormat.qrcode, code.data.codeUnits));
+      }
+    } on NoSuchMethodError {
+      // Do nothing, this happens continously in web release
+      // NoSuchMethodError: method not found: 'get$data' on null
     }
   }
 

--- a/lib/src/web/flutter_qr_web.dart
+++ b/lib/src/web/flutter_qr_web.dart
@@ -193,16 +193,11 @@ class _WebQrViewState extends State<WebQrView> {
       });
     }
 
-    try {
-      final code = jsQR(imgData.data, canvas.width, canvas.height);
-      // ignore: unnecessary_null_comparison
-      if (code != null && code.data != null) {
-        _scanUpdateController
-            .add(Barcode(code.data, BarcodeFormat.qrcode, code.data.codeUnits));
-      }
-    } on NoSuchMethodError {
-      // Do nothing, this happens continously in web release
-      // NoSuchMethodError: method not found: 'get$data' on null
+    final code = jsQR(imgData.data, canvas.width, canvas.height);
+    // ignore: unnecessary_null_comparison
+    if (code != null && code.data != null) {
+      _scanUpdateController
+          .add(Barcode(code.data, BarcodeFormat.qrcode, code.data.codeUnits));
     }
   }
 

--- a/lib/src/web/flutter_qr_web.dart
+++ b/lib/src/web/flutter_qr_web.dart
@@ -193,11 +193,17 @@ class _WebQrViewState extends State<WebQrView> {
       });
     }
 
-    final code = jsQR(imgData.data, canvas.width, canvas.height);
-    // ignore: unnecessary_null_comparison
-    if (code != null && code.data != null) {
-      _scanUpdateController
-          .add(Barcode(code.data, BarcodeFormat.qrcode, code.data.codeUnits));
+    try {
+      final code = jsQR(imgData.data, canvas.width, canvas.height);
+      // ignore: unnecessary_null_comparison
+      if (code != null && code.data != null) {
+        _scanUpdateController
+            .add(Barcode(code.data, BarcodeFormat.qrcode, code.data.codeUnits));
+      }
+    } on NoSuchMethodError {
+      // Do nothing, this exception occurs continously in web release when no
+      // code is found.
+      // NoSuchMethodError: method not found: 'get$data' on null
     }
   }
 


### PR DESCRIPTION
The web support in flutter_qr_web is working nicely but when the scanner cannot find a valid code it spams `NoSuchMethodError: method not found: 'get$data' on null`. I wrapped the code parsing logic in a try/catch to silence this error and in my use case this makes the qr scanner work without problems in the web browser.