### PR TITLE
fix: Does not crash in debug mode of iOS 14+

### DIFF
--- a/ios/Classes/FlutterQrPlugin.m
+++ b/ios/Classes/FlutterQrPlugin.m
@@ -8,6 +8,8 @@
 
 @implementation FlutterQrPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-    [SwiftFlutterQrPlugin registerWithRegistrar:registrar];
+    if (registrar) {
+        [SwiftFlutterQrPlugin registerWithRegistrar:registrar];
+    }
 }
 @end


### PR DESCRIPTION
In ios 14+, debug mode Flutter apps can only be launched from Flutter tooling, IDEs with Flutter plugins or from Xcode.
So, registrar will be nil.
However, we can't make it crash in its own plugin.