### PR TITLE
feat: 643 - now only looking for the specified formats

### DIFF
--- a/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
+++ b/android/src/main/kotlin/net/touchcapture/qr/flutterqr/QRView.kt
@@ -231,6 +231,12 @@ class QRView(
 
         val allowedBarcodeTypes = getAllowedBarcodeTypes(arguments, result)
 
+        if (arguments == null) {
+            barcodeView?.decoderFactory = DefaultDecoderFactory(null, null, null, 2)
+        } else {
+            barcodeView?.decoderFactory = DefaultDecoderFactory(allowedBarcodeTypes, null, null, 2)
+        }
+
         barcodeView?.decodeContinuous(
             object : BarcodeCallback {
                 override fun barcodeResult(result: BarcodeResult) {


### PR DESCRIPTION
Impacted file:
* `QRView.kt`: the allowed barcode types are enforced at the start of `startScan`, and not just filtered afterwards

It fixes the crash mentioned in #643 for android users on API 23 and lower.
It also potentially improved the performances.