### PR TITLE
Removed deprecated describeEnum method from example code

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -66,7 +66,7 @@ class _QRViewExampleState extends State<QRViewExample> {
                 children: <Widget>[
                   if (result != null)
                     Text(
-                        'Barcode Type: ${describeEnum(result!.format)}   Data: ${result!.code}')
+                        'Barcode Type: ${result!.format.name}   Data: ${result!.code}')
                   else
                     const Text('Scan a code'),
                   Row(
@@ -94,12 +94,12 @@ class _QRViewExampleState extends State<QRViewExample> {
                               await controller?.flipCamera();
                               setState(() {});
                             },
-                            child: FutureBuilder(
+                            child: FutureBuilder<CameraFacing>(
                               future: controller?.getCameraInfo(),
                               builder: (context, snapshot) {
                                 if (snapshot.data != null) {
                                   return Text(
-                                      'Camera facing ${describeEnum(snapshot.data!)}');
+                                      'Camera facing ${snapshot.data?.name}');
                                 } else {
                                   return const Text('loading');
                                 }


### PR DESCRIPTION
Removed deprecated `describeEnum `method from example code #721 