### PR TITLE
[48291] JSダイアログのconfirmが表示されない問題の修正

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -33,21 +33,21 @@ android {
     defaultConfig {
         // minSdkVersion is determined by Native View.
         minSdkVersion 20
-        targetSdkVersion 33
+        targetSdkVersion 34
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
     }
 
     kotlinOptions {
-        jvmTarget = '11'
+        jvmTarget = '17'
     }
 
     compileOptions {
         // Flag to enable support for the new language APIs
         coreLibraryDesugaringEnabled true
-        // Sets Java compatibility to Java 11
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        // Sets Java compatibility to Java 17
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     if (project.android.hasProperty('namespace')) {
         namespace 'net.touchcapture.qr.flutterqr'

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -36,7 +36,7 @@ android {
         applicationId "net.touchcapture.qr.flutterqrexample"
         // minSdkVersion is determined by Native View.
         minSdkVersion 20
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
<!--
*任意の項目について記述の必要がない場合は削除してください。*  
**緊急対応等でリリースすることを優先した場合は、対応後にWhyとWhatの記述をお願いします。**
-->

## Ticket
メインチケット
https://kbn.gladd.jp/issues/48291

サブチケット
https://kbn.gladd.jp/issues/48239
https://kbn.gladd.jp/issues/48340
https://kbn.gladd.jp/issues/48342


## Why
WLオンラインのセールをWebViewで表示したときに必要なJSイベントが走らずにアプリでは期待した動作が確認できないため
- JSのconfirm関数が走った時にWebViewでダイアログが表示されていないため

## What
- Webviewにconfirmダイアログが表示された時のハンドラーを追加しました。
- confirmのmessageを読み取ってFlutterのAlertDialogで表示する

関連のチケットが全て解消すると思います。

- [クレジットカード管理画面 登録済みのクレジットカードを削除できない（iOSのみ）](https://kbn.gladd.jp/issues/48239)
- [GLS=ONのアカウントで注文キャンセルボタンをタップしても何も起きない（iOSのみ）](https://kbn.gladd.jp/issues/48340)
- [返品時に「規約に同意の上、送信しますボタン」をタップしても何も起きない（iOSのみ）](https://kbn.gladd.jp/issues/48342)

## レビューポイント（任意）
<!--
レビュワーに特に確認してほしい点について記述します。  
レビュワーの負担軽減にも繋がります。  
不安な点があればレビュー時ではなく実装時に相談しましょう。
-->

## DoD
以下のコードをアプリで入力して確認をお願いします。もっと詳しく見たい場合は各チケットを見て欲しいです。
オンラインセール招待コード：hario2411


- [ ] [クレジットカード管理画面でクレジットカードを削除する時にダイアログが出て「OK」を押すと削除できる](https://kbn.gladd.jp/issues/48239)
- [ ] [注文キャンセルを行うとダイアログが表示されて「OK」を押すと操作が進む](https://kbn.gladd.jp/issues/48340)
- [ ] [返品時の「規約に同意の上、送信しますボタン」を押すとダイアログが出て「OK」を押すと操作が進む](https://kbn.gladd.jp/issues/48342)


## その他（任意）


## 関連するPR（任意）
<!--
プルリクエストのURLを記述します。  
関連しているプルリクエストが存在する場合は **必須** になります。
-->

